### PR TITLE
Configure postprocessor to produce surface normals 

### DIFF
--- a/config/elevation_maps/zed2i_map.yaml
+++ b/config/elevation_maps/zed2i_map.yaml
@@ -9,11 +9,11 @@
     robot_motion_map_update/covariance_scale_rotation_y: 0.0
     robot_motion_map_update/covariance_scale_rotation_z: 0.0
 
-    length_in_x: 20.0
-    length_in_y: 20.0
+    length_in_x: 12.0
+    length_in_y: 12.0
     position_x: 0.0
     position_y: 0.0
-    resolution: 0.35 #0.01
+    resolution: 0.15 #0.01
     min_variance: 0.0001
     max_variance: 0.05
     mahalanobis_distance_threshold: 2.5

--- a/config/postprocessing/postprocessor_pipeline.yaml
+++ b/config/postprocessing/postprocessor_pipeline.yaml
@@ -3,27 +3,37 @@ elevation_mapping:
   
     postprocessor_pipeline: # set by postprocessor_pipeline_name
       # Fill holes in the map with inpainting.
-      filter1:
-        name: inpaint
-        type: gridMapCv/InpaintFilter
-        params:
-          input_layer: elevation
-          output_layer: elevation_inpainted
-          radius: 0.05
+        # Inpaint filter is broken, stacktrace below:
+        #0  0x0000fffff6bb7724 in cv::_OutputArray::create(cv::Size_<int>, int, int, bool, cv::_OutputArray::DepthMask) const () 
+        #           from /lib/aarch64-linux-gnu/libopencv_core.so.4.5d
+        #1  0x0000fffff7a4c890 in cv::inpaint(cv::_InputArray const&, cv::_InputArray const&, cv::_OutputArray const&, double, int) () from /lib/libopencv_photo.so.408
+        #2  0x0000fffff7aa1c94 in ?? () from /opt/ros/humble/lib/libgrid_map_cv.so
+        #3  0x0000aaaaaab78fac in elevation_mapping::PostprocessingPipelineFunctor::operator()(grid_map::GridMap&) ()
+      # filter1:
+      #   name: inpaint
+      #   type: gridMapCv/InpaintFilter
+
+      #   params:
+      #     input_layer: elevation
+      #     output_layer: elevation_inpainted
+      #     radius: 0.05
+
 
       # Compute Surface normals
-      filter2:
+      filter1:
         name: surface_normals
         type: gridMapFilters/NormalVectorsFilter
         params:
-          input_layer: elevation_inpainted
+          # input_layer: elevation_inpainted
+          input_layer: elevation
           output_layers_prefix: normal_vectors_
-          radius: 0.1
+          radius: 0.3 # 1.5 times the map resolution is good
           normal_vector_positive_axis: z
 
       #  Delete layers that are not needed to reduce bandwidth
-      # filter3:
-      #   name: delete_original_layers
-      #   type: gridMapFilters/DeletionFilter
-      #   params:
-      #     layers: [lowest_scan_point,sensor_x_at_lowest_scan, sensor_y_at_lowest_scan, sensor_z_at_lowest_scan] # List of layers.
+      filter2:
+        name: delete_original_layers
+        type: gridMapFilters/DeletionFilter
+        params:
+          layers: [lowest_scan_point,sensor_x_at_lowest_scan, sensor_y_at_lowest_scan, sensor_z_at_lowest_scan] # List of layers.
+

--- a/config/postprocessing/postprocessor_pipeline.yaml
+++ b/config/postprocessing/postprocessor_pipeline.yaml
@@ -27,7 +27,7 @@ elevation_mapping:
           # input_layer: elevation_inpainted
           input_layer: elevation
           output_layers_prefix: normal_vectors_
-          radius: 0.45 # 1.5 times the map resolution is good
+          radius: 0.3 # 1.5 times the map resolution is good
           normal_vector_positive_axis: z
 
       #  Delete layers that are not needed to reduce bandwidth

--- a/config/postprocessing/postprocessor_pipeline.yaml
+++ b/config/postprocessing/postprocessor_pipeline.yaml
@@ -27,7 +27,7 @@ elevation_mapping:
           # input_layer: elevation_inpainted
           input_layer: elevation
           output_layers_prefix: normal_vectors_
-          radius: 0.3 # 1.5 times the map resolution is good
+          radius: 0.45 # 1.5 times the map resolution is good
           normal_vector_positive_axis: z
 
       #  Delete layers that are not needed to reduce bandwidth

--- a/config/robots/zed2i_robot.yaml
+++ b/config/robots/zed2i_robot.yaml
@@ -13,6 +13,6 @@
     robot_base_frame_id: "zed_left_camera_frame"
     robot_pose_with_covariance_topic: "/zed/zed_node/odom"
     track_point_frame_id: "zed_left_camera_frame"
-    track_point_x: 11.0
+    track_point_x: 6.5
     track_point_y: 0.0
     track_point_z: -0.5

--- a/config/zed_configs/zed2i.yaml
+++ b/config/zed_configs/zed2i.yaml
@@ -11,5 +11,5 @@
 
         depth:
             min_depth: 0.3 # Min: 0.3, Max: 3.0
-            max_depth: 13.0 # Max: 40.0
+            max_depth: 10.0 # Max: 40.0
 

--- a/rviz2/zed2i.rviz
+++ b/rviz2/zed2i.rviz
@@ -6,14 +6,9 @@ Panels:
       Expanded:
         - /Global Options1
         - /Status1
-        - /ElevationMap1
-        - /ElevationMapRaw1
-        - /ElevationMapRaw1/Topic1
-        - /TF1
         - /TF1/Tree1
-        - /ZedPointCloud1
       Splitter Ratio: 0.5423280596733093
-    Tree Height: 365
+    Tree Height: 725
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -58,10 +53,10 @@ Visualization Manager:
       Class: grid_map_rviz_plugin/GridMap
       Color: 200; 200; 200
       Color Layer: elevation
-      Color Transformer: GridMapLayer
-      Enabled: true
+      Color Transformer: IntensityLayer
+      Enabled: false
       Height Layer: elevation
-      Height Transformer: GridMapLayer
+      Height Transformer: Layer
       History Length: 1
       Invert Rainbow: false
       Max Color: 255; 255; 255
@@ -78,21 +73,21 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /elevation_map
       Use Rainbow: true
-      Value: true
+      Value: false
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Class: grid_map_rviz_plugin/GridMap
       Color: 200; 200; 200
-      Color Layer: elevation
-      Color Transformer: GridMapLayer
-      Enabled: false
+      Color Layer: normal_vectors_z
+      Color Transformer: IntensityLayer
+      Enabled: true
       Height Layer: elevation
       Height Transformer: GridMapLayer
       History Length: 1
       Invert Rainbow: false
-      Max Color: 255; 255; 255
+      Max Color: 0; 255; 0
       Max Intensity: 10
-      Min Color: 0; 0; 0
+      Min Color: 255; 0; 0
       Min Intensity: 0
       Name: ElevationMapRaw
       Show Grid Lines: true
@@ -104,7 +99,7 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /elevation_map_raw_post
       Use Rainbow: true
-      Value: false
+      Value: true
     - Class: rviz_default_plugins/TF
       Enabled: true
       Frame Timeout: 15
@@ -242,25 +237,25 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 25.060277938842773
+      Distance: 24.018983840942383
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: -3.228893756866455
-        Y: 19.825485229492188
-        Z: -3.853139638900757
+        X: 15.885583877563477
+        Y: 1.341249942779541
+        Z: -5.580367088317871
       Focal Shape Fixed Size: false
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.30479538440704346
+      Pitch: 0.3747949004173279
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 4.767096519470215
+      Yaw: 3.2420945167541504
     Saved: ~
 Window Geometry:
   Displays:

--- a/src/postprocessing/PostprocessingPipelineFunctor.cpp
+++ b/src/postprocessing/PostprocessingPipelineFunctor.cpp
@@ -48,7 +48,7 @@ grid_map::GridMap PostprocessingPipelineFunctor::operator()(GridMap& inputMap) {
     RCLCPP_WARN_ONCE(nodeHandle_->get_logger(), "No postprocessing pipeline was configured. Forwarding the raw elevation map!");
     return inputMap;
   }
-  RCLCPP_INFO(nodeHandle_->get_logger(), "performing Post processing");
+  RCLCPP_DEBUG(nodeHandle_->get_logger(), "performing Post processing");
   grid_map::GridMap outputMap;
   if (not filterChain_.update(inputMap, outputMap)) {
     RCLCPP_ERROR(nodeHandle_->get_logger(), "Could not perform the grid map filter chain! Forwarding the raw elevation map!");


### PR DESCRIPTION
Commented out the inpainting filter since it is broken. Adjust radius value of surface normals since it must be greater than the map resolution for it to work.

Here is what it looks like with a large map and a large map resolution. The colour intensity if the surface normal (aka slope).
![image](https://github.com/user-attachments/assets/3da164e3-3cb2-4e39-aef3-16f86f581cb8)

Need to give it more resolution which probably means shrinking the map size at the same time:
